### PR TITLE
#61 intercepts without annotations

### DIFF
--- a/src/Interceptor/CacheEvictInterceptor.php
+++ b/src/Interceptor/CacheEvictInterceptor.php
@@ -35,7 +35,7 @@ class CacheEvictInterceptor extends AbstractCache
      */
     public function invoke(MethodInvocation $invocation)
     {
-        $annotation = $invocation->getMethod()->getAnnotation($this->annotation);
+        $annotation = $invocation->getMethod()->getAnnotation($this->annotation) ?? new $this->annotation([]);
         $keys = $this->generateCacheName($annotation->cacheName, $invocation);
         if (!is_array($annotation->key)) {
             $annotation->key = [$annotation->key];

--- a/src/Interceptor/CachePutInterceptor.php
+++ b/src/Interceptor/CachePutInterceptor.php
@@ -35,7 +35,7 @@ class CachePutInterceptor extends AbstractCache
      */
     public function invoke(MethodInvocation $invocation)
     {
-        $annotation = $invocation->getMethod()->getAnnotation($this->annotation);
+        $annotation = $invocation->getMethod()->getAnnotation($this->annotation) ?? new $this->annotation([]);
         $keys = $this->generateCacheName($annotation->cacheName, $invocation);
         if (!is_array($annotation->key)) {
             $annotation->key = [$annotation->key];

--- a/src/Interceptor/CacheableInterceptor.php
+++ b/src/Interceptor/CacheableInterceptor.php
@@ -38,7 +38,7 @@ class CacheableInterceptor extends AbstractCache
     public function invoke(MethodInvocation $invocation)
     {
         /** @var Cacheable $annotation */
-        $annotation = $invocation->getMethod()->getAnnotation($this->annotation);
+        $annotation = $invocation->getMethod()->getAnnotation($this->annotation) ?? new $this->annotation([]);
         $keys = $this->generateCacheName($annotation->cacheName, $invocation);
         if (!is_array($annotation->key)) {
             $annotation->key = [$annotation->key];

--- a/src/Interceptor/LogExceptionsInterceptor.php
+++ b/src/Interceptor/LogExceptionsInterceptor.php
@@ -42,7 +42,7 @@ class LogExceptionsInterceptor extends AbstractLogger implements MethodIntercept
     public function invoke(MethodInvocation $invocation)
     {
         /** @var \Ytake\LaravelAspect\Annotation\LogExceptions $annotation */
-        $annotation = $invocation->getMethod()->getAnnotation($this->annotation);
+        $annotation = $invocation->getMethod()->getAnnotation($this->annotation) ?? new $this->annotation([]);
         try {
             $result = $invocation->proceed();
         } catch (\Exception $exception) {

--- a/src/Interceptor/LoggableInterceptor.php
+++ b/src/Interceptor/LoggableInterceptor.php
@@ -44,7 +44,7 @@ class LoggableInterceptor extends AbstractLogger implements MethodInterceptor
     public function invoke(MethodInvocation $invocation)
     {
         /** @var \Ytake\LaravelAspect\Annotation\Loggable $annotation */
-        $annotation = $invocation->getMethod()->getAnnotation($this->annotation);
+        $annotation = $invocation->getMethod()->getAnnotation($this->annotation) ?? new $this->annotation([]);
         $start = microtime(true);
         $result = $invocation->proceed();
         $time = number_format(microtime(true) - $start, 15);

--- a/src/Interceptor/MessageDrivenInterceptor.php
+++ b/src/Interceptor/MessageDrivenInterceptor.php
@@ -46,7 +46,7 @@ class MessageDrivenInterceptor implements MethodInterceptor
     public function invoke(MethodInvocation $invocation)
     {
         /** @var MessageDriven $annotation */
-        $annotation = $invocation->getMethod()->getAnnotation($this->annotation);
+        $annotation = $invocation->getMethod()->getAnnotation($this->annotation) ?? new $this->annotation([]);
         $command = new EagerMessage($invocation);
         if ($annotation->value instanceof LazyQueue) {
             $command = new LazyMessage($invocation);

--- a/src/Interceptor/QueryLogInterceptor.php
+++ b/src/Interceptor/QueryLogInterceptor.php
@@ -52,7 +52,7 @@ class QueryLogInterceptor extends AbstractLogger implements MethodInterceptor
     public function invoke(MethodInvocation $invocation)
     {
         /** @var \Ytake\LaravelAspect\Annotation\QueryLog $annotation */
-        $annotation = $invocation->getMethod()->getAnnotation($this->annotation);
+        $annotation = $invocation->getMethod()->getAnnotation($this->annotation) ?? new $this->annotation([]);
         $this->subscribeQueryLog();
         $result = $invocation->proceed();
         $logFormat = $this->queryLogFormatter($annotation, $invocation);

--- a/src/Interceptor/RetryOnFailureInterceptor.php
+++ b/src/Interceptor/RetryOnFailureInterceptor.php
@@ -47,7 +47,7 @@ final class RetryOnFailureInterceptor implements MethodInterceptor
     public function invoke(MethodInvocation $invocation)
     {
         /** @var RetryOnFailure $annotation */
-        $annotation = $invocation->getMethod()->getAnnotation($this->annotation);
+        $annotation = $invocation->getMethod()->getAnnotation($this->annotation) ?? new $this->annotation([]);
         $key = $this->keyName($invocation);
 
         if (isset(self::$attempt[$key]) === false) {

--- a/src/Interceptor/TransactionalInterceptor.php
+++ b/src/Interceptor/TransactionalInterceptor.php
@@ -47,7 +47,7 @@ class TransactionalInterceptor implements MethodInterceptor
      */
     public function invoke(MethodInvocation $invocation)
     {
-        $annotation = $invocation->getMethod()->getAnnotation($this->annotation);
+        $annotation = $invocation->getMethod()->getAnnotation($this->annotation) ?? new $this->annotation([]);
         // database connection name
         $connections = $annotation->value;
         if (!is_array($connections)) {


### PR DESCRIPTION
Case: pointcut methods without annotations:

```php
        return new Pointcut(
            (new Matcher)->any(),
            (new Matcher)->any(),
            [$this->interceptor]
        );
```

If method have no annotation - created new instance of annotation with default values.