### PR TITLE
update for laravel12

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-versions }} Test
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
@@ -24,7 +24,7 @@ jobs:
       run: composer validate
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -32,6 +32,6 @@ jobs:
           ${{ runner.os }}-php-
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-dist --no-progress --no-suggest
+      run: composer install --prefer-dist --no-progress
     - name: Run test suite
       run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ you must use the LoggableModule / LogExceptionsModule
 
 | params | description |
 |-----|-------|
-| value | log level (default: \Monolog\Logger::INFO) should Monolog Constants |
+| value | log level (default: Level::Info->value). Supports integer constants, Monolog Level enum values, or string level names ("debug", "info", etc.) |
 | skipResult | method result output to log |
 | name |log name prefix(default: Loggable) |
 | driver | logger driver or channel name [docs](https://laravel.com/docs/5.6/logging#configuration) |

--- a/composer.json
+++ b/composer.json
@@ -19,20 +19,20 @@
 
   "require": {
     "php": "^8.2",
-    "illuminate/console": "^11.0",
-    "illuminate/filesystem": "^11.0",
-    "illuminate/support": "^11.0",
-    "illuminate/config": "^11.0",
-    "illuminate/contracts": "^11.0",
-    "illuminate/log": "^11.0",
-    "illuminate/database": "^11.0",
-    "illuminate/cache": "^11.0",
-    "illuminate/events": "^11.0",
-    "illuminate/bus": "^11.0",
-    "illuminate/queue": "^11.0",
+    "illuminate/console": "^12.0",
+    "illuminate/filesystem": "^12.0",
+    "illuminate/support": "^12.0",
+    "illuminate/config": "^12.0",
+    "illuminate/contracts": "^12.0",
+    "illuminate/log": "^12.0",
+    "illuminate/database": "^12.0",
+    "illuminate/cache": "^12.0",
+    "illuminate/events": "^12.0",
+    "illuminate/bus": "^12.0",
+    "illuminate/queue": "^12.0",
     "ray/aop": "^2.9",
     "doctrine/annotations": "^1.10",
-    "nikic/php-parser": "^4.2",
+    "nikic/php-parser": "^5.0",
     "psr/log": "^1.0.1 || ^2.0 || ^3.0"
   },
   "require-dev": {
@@ -45,7 +45,7 @@
     "pdepend/pdepend" : "^2.2.4",
     "phpmd/phpmd": "@stable",
     "squizlabs/php_codesniffer": "~2.7",
-    "illuminate/encryption":"^11.0",
+    "illuminate/encryption":"^12.0",
     "vlucas/phpdotenv": "^5.2"
   },
   "autoload": {

--- a/src/Annotation/LogExceptions.php
+++ b/src/Annotation/LogExceptions.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 namespace Ytake\LaravelAspect\Annotation;
 
-use Monolog\Logger;
+use Monolog\Level;
 use Doctrine\Common\Annotations\Annotation;
 
 /**
@@ -28,8 +28,8 @@ use Doctrine\Common\Annotations\Annotation;
  */
 class LogExceptions extends LoggableAnnotate
 {
-    /** @var int  Log level */
-    public $value = Logger::ERROR;
+    /** @var int Log level */
+    public $value = Level::Error->value;
 
     /** @var string */
     public $expect = '\Exception';

--- a/src/Annotation/Loggable.php
+++ b/src/Annotation/Loggable.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 namespace Ytake\LaravelAspect\Annotation;
 
-use Monolog\Logger;
+use Monolog\Level;
 use Doctrine\Common\Annotations\Annotation;
 
 /**
@@ -28,8 +28,8 @@ use Doctrine\Common\Annotations\Annotation;
  */
 class Loggable extends LoggableAnnotate
 {
-    /** @var int  Log level */
-    public $value = Logger::INFO;
+    /** @var int Log level */
+    public $value = Level::Info->value;
 
     /** @var bool  */
     public $skipResult = false;

--- a/src/Annotation/QueryLog.php
+++ b/src/Annotation/QueryLog.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
  */
 namespace Ytake\LaravelAspect\Annotation;
 
-use Monolog\Logger;
+use Monolog\Level;
 use Doctrine\Common\Annotations\Annotation;
 
 /**
@@ -29,8 +29,8 @@ use Doctrine\Common\Annotations\Annotation;
  */
 class QueryLog extends Annotation
 {
-    /** @var int  Log level */
-    public $value = Logger::INFO;
+    /** @var int Log level */
+    public $value = Level::Info->value;
 
     /** @var string  */
     public $name = 'QueryLog';

--- a/src/AspectServiceProvider.php
+++ b/src/AspectServiceProvider.php
@@ -26,8 +26,6 @@ use Illuminate\Support\ServiceProvider;
  */
 class AspectServiceProvider extends ServiceProvider
 {
-    /** @var bool */
-    protected $defer = false;
 
     /**
      * boot aspect kernel

--- a/src/AspectServiceProvider.php
+++ b/src/AspectServiceProvider.php
@@ -26,7 +26,6 @@ use Illuminate\Support\ServiceProvider;
  */
 class AspectServiceProvider extends ServiceProvider
 {
-
     /**
      * boot aspect kernel
      */

--- a/src/Interceptor/AbstractLogger.php
+++ b/src/Interceptor/AbstractLogger.php
@@ -97,5 +97,4 @@ abstract class AbstractLogger
         // Default fallback
         return Level::Info->value;
     }
-
 }

--- a/src/Interceptor/AbstractLogger.php
+++ b/src/Interceptor/AbstractLogger.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace Ytake\LaravelAspect\Interceptor;
 
+use Monolog\Level;
 use Psr\Log\LoggerInterface;
 use Ray\Aop\MethodInvocation;
 use Ytake\LaravelAspect\Annotation\LoggableAnnotate;
@@ -55,7 +56,7 @@ abstract class AbstractLogger
         }
 
         return [
-            'level'   => $annotation->value,
+            'level'   => $this->normalizeLogLevel($annotation->value),
             'message' => sprintf(
                 $this->format,
                 $annotation->name,
@@ -73,4 +74,29 @@ abstract class AbstractLogger
     {
         static::$logger = $logger;
     }
+
+    /**
+     * Normalize log level to integer for Monolog addRecord()
+     * 
+     * @param mixed $level Monolog Level enum, integer constant, or string
+     * @return int
+     */
+    protected function normalizeLogLevel($level): int
+    {
+        if (is_int($level)) {
+            return $level;
+        }
+        
+        if (is_string($level)) {
+            return Level::fromName($level)->value;
+        }
+        
+        if ($level instanceof Level) {
+            return $level->value;
+        }
+        
+        // Default fallback
+        return Level::Info->value;
+    }
+
 }

--- a/src/Interceptor/AbstractLogger.php
+++ b/src/Interceptor/AbstractLogger.php
@@ -80,7 +80,7 @@ abstract class AbstractLogger
      * @param mixed $level Monolog Level enum, integer constant, or string
      * @return int
      */
-    protected function normalizeLogLevel($level): int
+    protected function normalizeLogLevel(mixed $level): int
     {
         if (is_int($level)) {
             return $level;

--- a/src/Interceptor/AbstractLogger.php
+++ b/src/Interceptor/AbstractLogger.php
@@ -77,7 +77,6 @@ abstract class AbstractLogger
 
     /**
      * Normalize log level to integer for Monolog addRecord()
-     * 
      * @param mixed $level Monolog Level enum, integer constant, or string
      * @return int
      */

--- a/src/Interceptor/LogExceptionsInterceptor.php
+++ b/src/Interceptor/LogExceptionsInterceptor.php
@@ -53,11 +53,7 @@ class LogExceptionsInterceptor extends AbstractLogger implements MethodIntercept
                 $logFormat['context']['code'] = $exception->getCode();
                 $logFormat['context']['error_message'] = $exception->getMessage();
                 if ($logger instanceof LogManager) {
-                    if (!is_null($annotation->driver)) {
-                        $logger = $logger->driver($annotation->driver);
-                    } else {
-                        $logger = $logger->driver();
-                    }
+                    $logger = $logger->driver($annotation->driver);
                     $logger->addRecord($logFormat['level'], $logFormat['message'], $logFormat['context']);
                 }
             }

--- a/src/Interceptor/LogExceptionsInterceptor.php
+++ b/src/Interceptor/LogExceptionsInterceptor.php
@@ -49,12 +49,14 @@ class LogExceptionsInterceptor extends AbstractLogger implements MethodIntercept
             if ($exception instanceof $annotation->expect) {
                 $logFormat = $this->logFormatter($annotation, $invocation);
                 $logger = static::$logger;
-                /** Monolog\Logger */
+                
                 $logFormat['context']['code'] = $exception->getCode();
                 $logFormat['context']['error_message'] = $exception->getMessage();
                 if ($logger instanceof LogManager) {
                     if (!is_null($annotation->driver)) {
                         $logger = $logger->driver($annotation->driver);
+                    } else {
+                        $logger = $logger->driver();
                     }
                     $logger->addRecord($logFormat['level'], $logFormat['message'], $logFormat['context']);
                 }

--- a/src/Interceptor/LoggableInterceptor.php
+++ b/src/Interceptor/LoggableInterceptor.php
@@ -50,14 +50,16 @@ class LoggableInterceptor extends AbstractLogger implements MethodInterceptor
         $time = number_format(microtime(true) - $start, 15);
         $logFormat = $this->logFormatter($annotation, $invocation);
         $logger = static::$logger;
+        
         if (!$annotation->skipResult) {
             $logFormat['context']['result'] = $result;
         }
         $logFormat['context']['time'] = $time;
-        /** Monolog\Logger */
         if ($logger instanceof LogManager) {
             if (!is_null($annotation->driver)) {
                 $logger = $logger->driver($annotation->driver);
+            } else {
+                $logger = $logger->driver();
             }
             $logger->addRecord($logFormat['level'], $logFormat['message'], $logFormat['context']);
         }

--- a/src/Interceptor/LoggableInterceptor.php
+++ b/src/Interceptor/LoggableInterceptor.php
@@ -56,11 +56,7 @@ class LoggableInterceptor extends AbstractLogger implements MethodInterceptor
         }
         $logFormat['context']['time'] = $time;
         if ($logger instanceof LogManager) {
-            if (!is_null($annotation->driver)) {
-                $logger = $logger->driver($annotation->driver);
-            } else {
-                $logger = $logger->driver();
-            }
+            $logger = $logger->driver($annotation->driver);
             $logger->addRecord($logFormat['level'], $logFormat['message'], $logFormat['context']);
         }
 

--- a/src/Interceptor/QueryLogInterceptor.php
+++ b/src/Interceptor/QueryLogInterceptor.php
@@ -60,6 +60,8 @@ class QueryLogInterceptor extends AbstractLogger implements MethodInterceptor
         if ($logger instanceof LogManager) {
             if (!is_null($annotation->driver)) {
                 $logger = $logger->driver($annotation->driver);
+            } else {
+                $logger = $logger->driver();
             }
             $logger->addRecord($logFormat['level'], $logFormat['message'], $logFormat['context']);
         }
@@ -91,7 +93,7 @@ class QueryLogInterceptor extends AbstractLogger implements MethodInterceptor
         MethodInvocation $invocation
     ): array {
         return [
-            'level'   => $annotation->value,
+            'level'   => $this->normalizeLogLevel($annotation->value),
             'message' => sprintf(
                 $this->format,
                 $annotation->name,

--- a/src/Interceptor/QueryLogInterceptor.php
+++ b/src/Interceptor/QueryLogInterceptor.php
@@ -58,11 +58,7 @@ class QueryLogInterceptor extends AbstractLogger implements MethodInterceptor
         $logFormat = $this->queryLogFormatter($annotation, $invocation);
         $logger = static::$logger;
         if ($logger instanceof LogManager) {
-            if (!is_null($annotation->driver)) {
-                $logger = $logger->driver($annotation->driver);
-            } else {
-                $logger = $logger->driver();
-            }
+            $logger = $logger->driver($annotation->driver);
             $logger->addRecord($logFormat['level'], $logFormat['message'], $logFormat['context']);
         }
         $this->queryLogs = [];

--- a/tests/AspectLogExceptionsTest.php
+++ b/tests/AspectLogExceptionsTest.php
@@ -40,13 +40,19 @@ class AspectLogExceptionsTest extends \AspectTestCase
 
     public function testShouldBeLogger()
     {
-         //$this->log->useFiles($this->getDir() . '/.testing.exceptions.log');
-        /** @var \__Test\AspectLoggable $cache */
+        /** @var \__Test\AspectLogExceptions $cache */
         $cache = $this->app->make(\__Test\AspectLogExceptions::class);
+        
+        // Clear any existing log
+        $logFile = __DIR__ . '/logs/laravel.log';
+        if (file_exists($logFile)) {
+            file_put_contents($logFile, '');
+        }
+        
         try {
             $cache->normalLog(1);
         } catch (\Exception $e) {
-            $put = $this->app['files']->get($this->getDir() . '/.testing.exceptions.log');
+            $put = file_get_contents($logFile);
             $this->assertStringContainsString('LogExceptions:__Test\AspectLogExceptions.normalLog', $put);
             $this->assertStringContainsString('"code":0,"error_message":"', $put);
         }
@@ -62,13 +68,19 @@ class AspectLogExceptionsTest extends \AspectTestCase
 
     public function testExpectException()
     {
-        // $this->log->useFiles($this->getDir() . '/.testing.exceptions.log');
         /** @var \__Test\AspectLogExceptions $cache */
         $cache = $this->app->make(\__Test\AspectLogExceptions::class);
+        
+        // Clear any existing log
+        $logFile = __DIR__ . '/logs/laravel.log';
+        if (file_exists($logFile)) {
+            file_put_contents($logFile, '');
+        }
+        
         try {
             $cache->expectException();
         } catch (\LogicException $e) {
-            $put = $this->app['files']->get($this->getDir() . '/.testing.exceptions.log');
+            $put = file_get_contents($logFile);
             $this->assertStringContainsString('LogExceptions:__Test\AspectLogExceptions.expectException', $put);
             $this->assertStringContainsString('"code":0,"error_message":"', $put);
         }

--- a/tests/AspectLoggableTest.php
+++ b/tests/AspectLoggableTest.php
@@ -30,8 +30,16 @@ class AspectLoggableTest extends \AspectTestCase
     {
         /** @var \__Test\AspectLoggable $cache */
         $cache = $this->app->make(\__Test\AspectLoggable::class);
+        
+        // Clear any existing log
+        $logFile = __DIR__ . '/logs/laravel.log';
+        if (file_exists($logFile)) {
+            file_put_contents($logFile, '');
+        }
+        
         $cache->normalLog(1);
-        $put = $this->app['files']->get($this->logDir() . '/.testing.log');
+        
+        $put = file_get_contents($logFile);
         $this->assertStringContainsString('Loggable:__Test\AspectLoggable.normalLog', $put);
         $this->assertStringContainsString('{"args":{"id":1},"result":1', $put);
     }
@@ -40,8 +48,16 @@ class AspectLoggableTest extends \AspectTestCase
     {
         /** @var \__Test\AspectLoggable $cache */
         $cache = $this->app->make(\__Test\AspectLoggable::class);
+        
+        // Clear any existing log
+        $logFile = __DIR__ . '/logs/laravel.log';
+        if (file_exists($logFile)) {
+            file_put_contents($logFile, '');
+        }
+        
         $cache->skipResultLog(1);
-        $put = $this->app['files']->get($this->logDir() . '/.testing.log');
+        
+        $put = file_get_contents($logFile);
         $this->assertStringContainsString('Loggable:__Test\AspectLoggable.skipResultLog', $put);
         $this->assertStringNotContainsString('"result":1', $put);
     }

--- a/tests/AspectQueryLogTest.php
+++ b/tests/AspectQueryLogTest.php
@@ -32,8 +32,16 @@ class AspectQueryLogTest extends \AspectTestCase
     {
         /** @var AspectQueryLog $concrete */
         $concrete = $this->app->make(AspectQueryLog::class);
+        
+        // Clear any existing log
+        $logFile = __DIR__ . '/logs/laravel.log';
+        if (file_exists($logFile)) {
+            file_put_contents($logFile, '');
+        }
+        
         $concrete->start();
-        $put = $this->app['files']->get($this->logDir() . '/.testing.log');
+        
+        $put = file_get_contents($logFile);
         $this->assertStringContainsString('INFO: QueryLog:__Test\AspectQueryLog.start', $put);
         $this->assertStringContainsString('SELECT date(\'now\')', $put);
     }
@@ -42,8 +50,16 @@ class AspectQueryLogTest extends \AspectTestCase
     {
         /** @var AspectQueryLog $concrete */
         $concrete = $this->app->make(AspectQueryLog::class);
+        
+        // Clear any existing log
+        $logFile = __DIR__ . '/logs/laravel.log';
+        if (file_exists($logFile)) {
+            file_put_contents($logFile, '');
+        }
+        
         $concrete->multipleDatabaseAppendRecord();
-        $put = $this->app['files']->get($this->logDir() . '/.testing.log');
+        
+        $put = file_get_contents($logFile);
         $this->assertStringContainsString('INFO: QueryLog:__Test\AspectQueryLog.multipleDatabaseAppendRecord', $put);
         $this->assertStringContainsString('"queries":[{"query":"CREATE TABLE tests (test varchar(255) NOT NULL)"', $put);
     }

--- a/tests/LogLevelNormalizationTest.php
+++ b/tests/LogLevelNormalizationTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use Monolog\Level;
+use Ytake\LaravelAspect\Interceptor\AbstractLogger;
+
+/**
+ * normalizeLogLevelメソッドをテストするためのテストクラス
+ */
+class LogLevelNormalizationTest extends \PHPUnit\Framework\TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testNormalizeLogLevelWithIntegerValues()
+    {
+        $logger = new TestableAbstractLogger();
+        
+        // 整数値はそのまま返される
+        $this->assertSame(100, $logger->testNormalizeLogLevel(100)); // Debug
+        $this->assertSame(200, $logger->testNormalizeLogLevel(200)); // Info
+        $this->assertSame(250, $logger->testNormalizeLogLevel(250)); // Notice
+        $this->assertSame(300, $logger->testNormalizeLogLevel(300)); // Warning
+        $this->assertSame(400, $logger->testNormalizeLogLevel(400)); // Error
+        $this->assertSame(500, $logger->testNormalizeLogLevel(500)); // Critical
+        $this->assertSame(550, $logger->testNormalizeLogLevel(550)); // Alert
+        $this->assertSame(600, $logger->testNormalizeLogLevel(600)); // Emergency
+    }
+
+    public function testNormalizeLogLevelWithStringValues()
+    {
+        $logger = new TestableAbstractLogger();
+        
+        // 文字列値はLevel::fromName()で適切な整数値に変換される
+        $this->assertSame(100, $logger->testNormalizeLogLevel('debug'));
+        $this->assertSame(200, $logger->testNormalizeLogLevel('info'));
+        $this->assertSame(250, $logger->testNormalizeLogLevel('notice'));
+        $this->assertSame(300, $logger->testNormalizeLogLevel('warning'));
+        $this->assertSame(400, $logger->testNormalizeLogLevel('error'));
+        $this->assertSame(500, $logger->testNormalizeLogLevel('critical'));
+        $this->assertSame(550, $logger->testNormalizeLogLevel('alert'));
+        $this->assertSame(600, $logger->testNormalizeLogLevel('emergency'));
+    }
+
+    public function testNormalizeLogLevelWithLevelEnum()
+    {
+        $logger = new TestableAbstractLogger();
+        
+        // Level enumはvalueプロパティを返す
+        $this->assertSame(100, $logger->testNormalizeLogLevel(Level::Debug));
+        $this->assertSame(200, $logger->testNormalizeLogLevel(Level::Info));
+        $this->assertSame(250, $logger->testNormalizeLogLevel(Level::Notice));
+        $this->assertSame(300, $logger->testNormalizeLogLevel(Level::Warning));
+        $this->assertSame(400, $logger->testNormalizeLogLevel(Level::Error));
+        $this->assertSame(500, $logger->testNormalizeLogLevel(Level::Critical));
+        $this->assertSame(550, $logger->testNormalizeLogLevel(Level::Alert));
+        $this->assertSame(600, $logger->testNormalizeLogLevel(Level::Emergency));
+    }
+
+    public function testNormalizeLogLevelWithCaseInsensitiveStrings()
+    {
+        $logger = new TestableAbstractLogger();
+        
+        // 大文字小文字を問わず正しく変換される
+        $this->assertSame(200, $logger->testNormalizeLogLevel('INFO'));
+        $this->assertSame(200, $logger->testNormalizeLogLevel('Info'));
+        $this->assertSame(400, $logger->testNormalizeLogLevel('ERROR'));
+        $this->assertSame(400, $logger->testNormalizeLogLevel('Error'));
+    }
+
+    public function testNormalizeLogLevelWithInvalidInput()
+    {
+        $logger = new TestableAbstractLogger();
+        
+        // 無効な入力の場合はデフォルト値（Info）を返す
+        $this->assertSame(200, $logger->testNormalizeLogLevel(null));
+        $this->assertSame(200, $logger->testNormalizeLogLevel([]));
+        $this->assertSame(200, $logger->testNormalizeLogLevel(new \stdClass()));
+    }
+
+    public function testNormalizeLogLevelWithUnknownString()
+    {
+        $logger = new TestableAbstractLogger();
+        
+        // 未知の文字列の場合は例外が発生することを確認
+        $this->expectException(\UnhandledMatchError::class);
+        $logger->testNormalizeLogLevel('unknown');
+    }
+}
+
+/**
+ * AbstractLoggerのテスト用サブクラス
+ */
+class TestableAbstractLogger extends AbstractLogger
+{
+    /**
+     * normalizeLogLevelメソッドをテスト可能にするためのパブリックラッパー
+     */
+    public function testNormalizeLogLevel($level): int
+    {
+        return $this->normalizeLogLevel($level);
+    }
+}

--- a/tests/MessageDrivenFunctionalTest.php
+++ b/tests/MessageDrivenFunctionalTest.php
@@ -35,8 +35,16 @@ class MessageDrivenFunctionalTest extends AspectTestCase
         $this->expectOutputString('this');
         /** @var AspectMessageDriven $concrete */
         $concrete = $this->app->make(AspectMessageDriven::class);
+        
+        // Clear any existing log
+        $logFile = __DIR__ . '/logs/laravel.log';
+        if (file_exists($logFile)) {
+            file_put_contents($logFile, '');
+        }
+        
         $concrete->exec('this');
-        $put = $this->app['files']->get($this->logDir() . '/.testing.log');
+        
+        $put = file_get_contents($logFile);
         $this->assertStringContainsString('Loggable:__Test\AspectMessageDriven.exec {"args":{"param":"this"}', $put);
         $this->assertStringContainsString('Queued:__Test\AspectMessageDriven.logWith', $put);
     }
@@ -45,8 +53,16 @@ class MessageDrivenFunctionalTest extends AspectTestCase
     {
         /** @var AspectMessageDriven $concrete */
         $concrete = $this->app->make(AspectMessageDriven::class);
+        
+        // Clear any existing log
+        $logFile = __DIR__ . '/logs/laravel.log';
+        if (file_exists($logFile)) {
+            file_put_contents($logFile, '');
+        }
+        
         $concrete->eagerExec('testing');
-        $put = $this->app['files']->get($this->logDir() . '/.testing.log');
+        
+        $put = file_get_contents($logFile);
         $this->assertStringContainsString('Queued:__Test\AspectMessageDriven.logWith', $put);
     }
 


### PR DESCRIPTION
Hi @ytake 

**Changes for Laravel 12 Compatibility**
1. Support for Monolog 3.x
   - Migration from deprecated constants like Logger::DEBUG to the Level enum
   - Use of enum values such as Level::Info->value in annotations
2. Maintaining Backward Compatibility
   - Supports integers, Level enums, and string level names
   - Designed not to break existing code
3. Additional Tests
   - Comprehensive testing in LogLevelNormalizationTest
   - Maintenance and updates of existing tests
4. Documentation Updates
   - Explanation of the new log level specifications in the README
5. Dependency Updates
   - Laravel 12.x support in composer.json