### PR TITLE
fix: use explicit nullable types to resolve PHP 8.4 deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "illuminate/events": "^12.0",
     "illuminate/bus": "^12.0",
     "illuminate/queue": "^12.0",
-    "ray/aop": "^2.9",
+    "ray/aop": "^2.9 <2.19.0",
     "doctrine/annotations": "^1.10",
     "nikic/php-parser": "^5.0",
     "psr/log": "^1.0.1 || ^2.0 || ^3.0"

--- a/src/AspectDriverInterface.php
+++ b/src/AspectDriverInterface.php
@@ -28,7 +28,7 @@ interface AspectDriverInterface
      *
      * @return void
      */
-    public function register(string $module = null): void;
+    public function register(?string $module = null): void;
 
     /**
      * weaving

--- a/src/Console/ModulePublishCommand.php
+++ b/src/Console/ModulePublishCommand.php
@@ -133,7 +133,7 @@ class ModulePublishCommand extends Command
      *
      * @return string
      */
-    protected function parseClassName(string $name, string $moduleDirectory = null): string
+    protected function parseClassName(string $name, ?string $moduleDirectory = null): string
     {
         $rootNamespace = $this->laravel->getNamespace();
 

--- a/src/RayAspectKernel.php
+++ b/src/RayAspectKernel.php
@@ -85,7 +85,7 @@ class RayAspectKernel implements AspectDriverInterface
      *
      * @throws ClassNotFoundException
      */
-    public function register(string $module = null): void
+    public function register(?string $module = null): void
     {
         if (!class_exists($module)) {
             throw new ClassNotFoundException($module);

--- a/src/RayAspectKernel.php
+++ b/src/RayAspectKernel.php
@@ -87,7 +87,7 @@ class RayAspectKernel implements AspectDriverInterface
      */
     public function register(?string $module = null): void
     {
-        if (!class_exists($module)) {
+        if ($module === null || !class_exists($module)) {
             throw new ClassNotFoundException($module);
         }
         $this->modules[] = new $module;


### PR DESCRIPTION

  Hi @ytake                                                                                                                                                                                                                        
                                                                                                                                                                                                                                        
  Changes for PHP 8.4 Compatibility                                                                                                                                                                                                     
  1. Fix Implicitly Nullable Parameter Deprecation
    - PHP 8.4 deprecated implicitly marking parameters as nullable (e.g. string $param = null)                                                                                                                                          
    - Changed to explicit nullable types (e.g. ?string $param = null)                         
  2. Affected Files                                                                                                                                                                                                                     
    - src/AspectDriverInterface.php - register() method                                                                                                                                                                               
    - src/RayAspectKernel.php - register() method                                                                                                                                                                                       
    - src/Console/ModulePublishCommand.php - parseClassName() method                                                                                                                                                                  
  3. Null Safety Improvement                                                                                                                                                                                                            
    - Added null check in RayAspectKernel::register() before calling class_exists() to prevent TypeError under strict_types=1  